### PR TITLE
GATA Hub reward epoch details

### DIFF
--- a/public/data/gatarevenue.json
+++ b/public/data/gatarevenue.json
@@ -1,7 +1,14 @@
 [
+  {
+        "title": "GATA DAO EPOCH 27",
+        "desc": "GATA DOA epoch 27 from October 1st 2024 to October 31st 2024. Where 896/1887 eligible holders of GATAc & GATAv NFTs earned 0.18 $ATOM per GATA.",
+        "atomeDist": 160,
+        "date": "November 1st 2024",
+        "href": "https://docs.gatahub.zone/welcome-to-gitbook/gatahub/gata-nft-dao/dao-revenue-distribution#gata-dao-epoch-27"
+    },
    {
         "title": "GATA DAO EPOCH 26",
-        "desc": "GATA DOA epoch 26 from September 1st 2024 to September 31st 2024. Where 882/1887 eligible holders of GATAc & GATAv NFTs earned 0.16 $ATOM per GATA.",
+        "desc": "GATA DOA epoch 26 from September 1st 2024 to September 30th 2024. Where 882/1887 eligible holders of GATAc & GATAv NFTs earned 0.16 $ATOM per GATA.",
         "atomeDist": 158,
         "date": "October 2nd 2024",
         "href": "https://docs.gatahub.zone/welcome-to-gitbook/gatahub/gata-nft-dao/dao-revenue-distribution#gata-dao-epoch-26"

--- a/public/data/ygepoch.json
+++ b/public/data/ygepoch.json
@@ -1,4 +1,64 @@
 [
+   {
+      "title": "YG Epoch 20",
+      "date": "1st November 2024",
+      "href": "https://docs.gatahub.zone/welcome-to-gitbook/gatahub/yield-gorillas/yg-reward-distributions#yg-epoch-20",
+      "rewards": [
+        {
+          "nfts": [
+            {
+              "icon": "/ygrewards/bull.png",
+              "title": "Bull"
+            },
+            {
+              "icon": "/ygrewards/legend.png",
+              "title": "Legend"
+            }
+          ],
+          "reward": 0.15,
+          "revenue": 12
+        },
+        {
+          "nfts": [
+            {
+              "icon": "/ygrewards/mooned.png",
+              "title": "Mooned"
+            }
+          ],
+          "reward": 0.08,
+          "revenue": 15
+        },
+        {
+          "nfts": [
+            {
+              "icon": "/ygrewards/bear.png",
+              "title": "Bear"
+            },
+            {
+              "icon": "/ygrewards/pump.png",
+              "title": "pump"
+            }
+          ],
+          "reward": 0.06,
+          "revenue": 30
+        },
+        {
+          "nfts": [
+            {
+              "icon": "/ygrewards/neat.png",
+              "title": "Neat"
+            },
+            {
+              "icon": "/ygrewards/elemental.png",
+              "title": "Elemental"
+            }
+          ],
+          "reward": 0.0165,
+          "revenue": 38
+        }
+      ]
+    },
+  
   {
       "title": "YG Epoch 19",
       "date": "2nd October 2024",

--- a/public/data/ypReward.json
+++ b/public/data/ypReward.json
@@ -1,4 +1,62 @@
-[
+[ 
+    {
+        "title": "YP Epoch 07",
+        "date": "2nd November 2024",
+        "href": "https://docs.gatahub.zone/welcome-to-gitbook/gatahub/yield-paws/yp-reward-distribution#yp-epoch-7",
+        "rewards": [
+          {
+            "nfts": [
+              {
+                "icon": "/yprewards/01.png",
+                "title": "Brown Fur"
+              }
+            ],
+            "reward": 170.0,
+            "revenue": 9
+          },
+          {
+            "nfts": [
+              {
+                "icon": "/yprewards/02.png",
+                "title": "Grey Fur"
+              }
+            ],
+            "reward": 85.0,
+            "revenue": 13.5
+          },
+          {
+            "nfts": [
+              {
+                "icon": "/yprewards/03.png",
+                "title": "Black Fur"
+              }
+            ],
+            "reward": 38.0,
+            "revenue": 16
+          },
+          {
+            "nfts": [
+              {
+                "icon": "/yprewards/04.png",
+                "title": "White Fur"
+              }
+            ],
+            "reward": 34.0,
+            "revenue": 18
+          },
+          {
+            "nfts": [
+              {
+                "icon": "/yprewards/05.png",
+                "title": "Orange Fur"
+              }
+            ],
+            "reward": 30.0,
+            "revenue": 43.5
+          }
+        ]
+      },
+     
     {
         "title": "YP Epoch 06",
         "date": "1st October 2024",


### PR DESCRIPTION
All NFT reward epoch for the month of November 2024 added. 